### PR TITLE
Adds support for format faceting in mncatdiscovery

### DIFF
--- a/lib/mncatdiscovery.js
+++ b/lib/mncatdiscovery.js
@@ -63,6 +63,18 @@ const mncatdiscovery = stampit()
     };
   },
 
+  formats () {
+    return {
+      archive: 'Arhival/MSS Mtls',
+      audio: 'Audio',
+      books: 'Books',
+      journals: 'Journals',
+      maps: 'Maps',
+      scores: 'Scores',
+      video: 'Video',
+    };
+  },
+
   baseUri () {
     return URI({
       protocol: 'https',
@@ -87,7 +99,7 @@ const mncatdiscovery = stampit()
     return this.baseUri();
   },
 
-  uriFor (search, scope, field) {
+  uriFor (search, scope, field, format) {
     if (!search) {
       return [
         this.emptySearchWarning,
@@ -123,6 +135,17 @@ const mncatdiscovery = stampit()
       }
     }
     queryParams['query'] = (mncatField || 'any') + ',contains,' + search;
+
+    if (format) {
+      const formats = this.formats();
+      if (format in formats) {
+        mncatFormat = format;
+        // Facet is excluded from the query if not supplied, rather than a default
+        queryParams['facet'] = 'rtype,exact' + mncatFormat;
+      } else {
+        warnings.push('Unrecognized format: "' + format + '"');
+      }
+    }
 
     return [
       warnings.join(' '),

--- a/lib/mncatdiscovery.js
+++ b/lib/mncatdiscovery.js
@@ -139,9 +139,8 @@ const mncatdiscovery = stampit()
     if (format) {
       const formats = this.formats();
       if (format in formats) {
-        mncatFormat = format;
         // Facet is excluded from the query if not supplied, rather than a default
-        queryParams['facet'] = 'rtype,exact' + mncatFormat;
+        queryParams['facet'] = 'rtype,exact,' + format;
       } else {
         warnings.push('Unrecognized format: "' + format + '"');
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nihiliad/janus-uri-factory-plugins",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Plugins for the Janus uri-factory.",
   "main": "index.js",
   "scripts": {
@@ -34,7 +34,7 @@
     "tape": "^3.0.0"
   },
   "dependencies": {
-    "@nihiliad/janus": "^0.0.0",
+    "@nihiliad/janus": "^1.1.0",
     "bluebird": "^2.9.34",
     "require-all": "^2.0.0",
     "stampit": "^2.1.1",

--- a/test/mncatdiscovery.js
+++ b/test/mncatdiscovery.js
@@ -37,6 +37,12 @@ test('mncatdiscovery uriFor() missing "search" arguments', function (t) {
       scope: 'plant_pathology',
       field: 'title',
     },
+    '"scope", "field", and "format" arguments have truthy values': {
+      search: 0,
+      scope: 'plant_pathology',
+      field: 'title',
+      format: 'books'
+    },
   };
   tester.missingSearchArgs(t, plugin, testCases);
 });

--- a/test/mncatdiscovery.js
+++ b/test/mncatdiscovery.js
@@ -78,6 +78,18 @@ test('mncatdiscovery uriFor() valid "search" arguments', function (t) {
       scope: 'givens',
       field: 'title',
     },
+    'https://primo.lib.umn.edu/primo-explore/search?institution=TWINCITIES&vid=TWINCITIES&dum=true&highlight=true&lang=en_US&search_scope=givens&query=title%2Ccontains%2Cinvisible+man&facet=rtype%2Cexact%2Cbooks': {
+      search: 'invisible man',
+      scope: 'givens',
+      field: 'title',
+      format: 'books',
+    },
+    'https://primo.lib.umn.edu/primo-explore/search?institution=TWINCITIES&vid=TWINCITIES&dum=true&highlight=true&lang=en_US&search_scope=mncat_discovery&query=any%2Ccontains%2Cdarwin&facet=rtype%2Cexact%2Caudio': {
+      search: 'darwin',
+      scope: null,
+      field: null,
+      format: 'audio',
+    },
   };
 
   function getResultCount (html) {


### PR DESCRIPTION
Adds `format=` support to `mncatdiscovery.js` implemented as a query argument

    &facet=rtype,exact,{inputformat}

Unlike scope & field, Primo will not accept the default material type of `all_items` in the query. Usage of `all_items` in Primo results in a search omitting the `facet=rtype,exact...` entirely, so the plugin omits it as a valid format. If no format is specified, no `facet=` query param will be appended.

**NOTE**: The TravisCI build (`npm test` action) depends on https://github.com/UMNLibraries/janus/pull/11 to be merged.  Appears that when travis does `npm install`, it's only able to retrieve the current tagged `@nihiliad/janus` at `master` whose `uri-factory/plugin-tester.js` doesn't know how to pass format args.

With a local clone, tests pass when the npm installed `node_modules/@nihiliad/janus` is replaced with that repo's `format-support` branch.  I'm open to schooling on the right way to substitute an active branch with `npm install` and package.json...