### PR TITLE
Google custom search

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Plugins for the [Janus URI factory](https://github.com/UMNLibraries/janus#uri-fa
 
 - [Scopes and Formats](#scopes-and-formats)
 	- [ArchiveSpace](#archivespace)
-	- [GoogleSearchAppliance](#googlesearchappliance)
+	- [GoogleCustomSearch](#googlecustomsearch)
 	- [MncatDiscovery](#mncatdiscovery)
 	- [PubMed](#pubmed)
 	- [UMedia](#umedia)
@@ -68,16 +68,11 @@ Name/Description                      | Collection URL                          
 University of Minnesota - Twin Cities | https://conservancy.umn.edu/handle/11299/1      | 1
 Articles and Scholarly Works          | https://conservancy.umn.edu/handle/11299/169792 | 169792
 
-### GoogleSearchAppliance
+### Google Custom Search
+Performs a search via the Google Custom Search endpoint configured at
+https://www.lib.umn.edu/search.
 
-Because the Google Search Appliance can be used to search many UMN websites, this
-plugin requires a scope, which specifies which website to search. If scope is
-missing, it will default to `main`.
-
-Description | Value
-------|------------
-UMN Libraries Main Website | main
-UMN Health Sciences Libraries Website | hsl
+Google Custom Search has no custom scopes and no fields.
 
 ### MncatDiscovery
 #### MncatDiscovery Scopes

--- a/lib/googlecustomsearch.js
+++ b/lib/googlecustomsearch.js
@@ -1,0 +1,33 @@
+'use strict';
+const stampit = require('stampit');
+const URI = require('urijs');
+const plugin = require('@nihiliad/janus/uri-factory/plugin');
+
+const googlecustomsearch = stampit()
+.methods({
+  fields () { return {}; },
+  baseUri () {
+    return URI({
+      protocol: 'https',
+      hostname: 'www.lib.umn.edu',
+    }).segmentCoded([
+      'search',
+    ]).query({
+      // no base query params needed
+    });
+  },
+  uriFor (search, scope, field) {
+    if (!search) {
+      return [
+        this.emptySearchWarning,
+        this.emptySearchUri(),
+      ];
+    }
+    return [
+      '',
+      this.baseUri().addQuery({query: search}),
+    ];
+  },
+});
+
+module.exports = plugin.compose(googlecustomsearch);

--- a/test/googlecustomsearch.js
+++ b/test/googlecustomsearch.js
@@ -45,12 +45,11 @@ test('googlecustomsearch plugin uriFor() valid "search" arguments', function (t)
   };
 
   function getResultCount (html) {
-    //const $ = cheerio.load(html);
-    //const elem = $('#resInfo-1');
-    //// Displays like "About 1,294 results", strip out the comma
-    //const matches = $(elem[0]).text().trim().replace(/,/, '').match(/About (\d+) sorted/);
-    //const count = matches[1];
-    //return parseInt(count, 10);
+    // const elem = $('#resInfo-1');
+    // // Displays like "About 1,294 results", strip out the comma
+    // const matches = $(elem[0]).text().trim().replace(/,/, '').match(/About (\d+) sorted/);
+    // const count = matches[1];
+    // return parseInt(count, 10);
 
     // Our /search endpoint loads Google code that does search via XHR
     // and returns to build results via JS. Current test runner

--- a/test/googlecustomsearch.js
+++ b/test/googlecustomsearch.js
@@ -1,0 +1,62 @@
+'use strict';
+const test = require('tape');
+const cheerio = require('cheerio');
+const plugin = require('../').googlecustomsearch();
+const tester = require('@nihiliad/janus/uri-factory/plugin-tester')({runIntegrationTests: false});
+
+test('pubmed plugin default scopes', function (t) {
+  t.deepEqual(plugin.scopes(), {}, 'scopes() correctly returns the default empty object');
+  t.end();
+});
+
+test('pubmed plugin fields override', function (t) {
+  t.deepEqual(plugin.fields(), {}, 'fields correctly overridden with an empty object');
+  t.end();
+});
+
+test('pubmed plugin baseUri()', function (t) {
+  tester.baseUri(t, plugin, 'https://www.lib.umn.edu/search');
+});
+
+test('pubmed plugin emptySearchUri()', function (t) {
+  tester.emptySearchUri(t, plugin, 'https://www.lib.umn.edu/search');
+});
+
+test('pubmed plugin uriFor() missing "search" arguments', function (t) {
+  // testCases map state descriptions to uriFor() arguments
+  const testCases = {
+    'all arguments are null': {
+      search: null,
+      scope: null,
+      field: null,
+    },
+  };
+  tester.missingSearchArgs(t, plugin, testCases);
+});
+
+test('googlecustomsearch plugin uriFor() valid "search" arguments', function (t) {
+  // testCases map expected uri to uriFor() arguments
+  const testCases = {
+    'https://www.lib.umn.edu/search?query=math': {
+      search: 'math',
+      scope: null,
+      field: null,
+    },
+  };
+
+  function getResultCount (html) {
+    //const $ = cheerio.load(html);
+    //const elem = $('#resInfo-1');
+    //// Displays like "About 1,294 results", strip out the comma
+    //const matches = $(elem[0]).text().trim().replace(/,/, '').match(/About (\d+) sorted/);
+    //const count = matches[1];
+    //return parseInt(count, 10);
+
+    // Our /search endpoint loads Google code that does search via XHR
+    // and returns to build results via JS. Current test runner
+    // does not support checking this, would need something like Selenium
+    return 1;
+  };
+
+  tester.validSearchArgs(t, plugin, testCases, getResultCount);
+});


### PR DESCRIPTION
Adds a `googlecustomsearch` plugin.  Note: Integration test is commented out because it would require a test suite that can perform an AJAX request beyond just retrieving HTML.