### PR TITLE
HSL-specific google custom search plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Plugins for the [Janus URI factory](https://github.com/UMNLibraries/janus#uri-fa
 
 - [Scopes and Formats](#scopes-and-formats)
 	- [ArchiveSpace](#archivespace)
-	- [GoogleCustomSearch](#googlecustomsearch)
+	- [GoogleCustomSearch](#google-custom-search)
+	- [GoogleCustomSearchHSL](#google-custom-search-hsl)
 	- [MncatDiscovery](#mncatdiscovery)
 	- [Primo](#primo)
 	- [PubMed](#pubmed)
@@ -75,6 +76,12 @@ Performs a search via the Google Custom Search endpoint configured at
 https://www.lib.umn.edu/search.
 
 Google Custom Search has no custom scopes and no fields.
+
+### Google Custom Search HSL
+Performs a search via the HSL Google Custom Search endpoint configured at
+https://hsl.lib.umn.edu/search.
+
+Google Custom Search HSL has no custom scopes and no fields.
 
 ### MncatDiscovery
 Alias of [Primo](#primo).

--- a/lib/googlecustomsearchhsl.js
+++ b/lib/googlecustomsearchhsl.js
@@ -1,0 +1,33 @@
+'use strict';
+const stampit = require('stampit');
+const URI = require('urijs');
+const plugin = require('@nihiliad/janus/uri-factory/plugin');
+
+const googlecustomsearchhsl = stampit()
+.methods({
+  fields () { return {}; },
+  baseUri () {
+    return URI({
+      protocol: 'https',
+      hostname: 'hsl.lib.umn.edu',
+    }).segmentCoded([
+      'search',
+    ]).query({
+      // no base query params needed
+    });
+  },
+  uriFor (search, scope, field) {
+    if (!search) {
+      return [
+        this.emptySearchWarning,
+        this.emptySearchUri(),
+      ];
+    }
+    return [
+      '',
+      this.baseUri().addQuery({query: search}),
+    ];
+  },
+});
+
+module.exports = plugin.compose(googlecustomsearchhsl);

--- a/test/googlecustomsearch.js
+++ b/test/googlecustomsearch.js
@@ -4,25 +4,25 @@ const cheerio = require('cheerio');
 const plugin = require('../').googlecustomsearch();
 const tester = require('@nihiliad/janus/uri-factory/plugin-tester')({runIntegrationTests: false});
 
-test('pubmed plugin default scopes', function (t) {
+test('googlecustomsearch plugin default scopes', function (t) {
   t.deepEqual(plugin.scopes(), {}, 'scopes() correctly returns the default empty object');
   t.end();
 });
 
-test('pubmed plugin fields override', function (t) {
+test('googlecustomsearch plugin fields override', function (t) {
   t.deepEqual(plugin.fields(), {}, 'fields correctly overridden with an empty object');
   t.end();
 });
 
-test('pubmed plugin baseUri()', function (t) {
+test('googlecustomsearch plugin baseUri()', function (t) {
   tester.baseUri(t, plugin, 'https://www.lib.umn.edu/search');
 });
 
-test('pubmed plugin emptySearchUri()', function (t) {
+test('googlecustomsearch plugin emptySearchUri()', function (t) {
   tester.emptySearchUri(t, plugin, 'https://www.lib.umn.edu/search');
 });
 
-test('pubmed plugin uriFor() missing "search" arguments', function (t) {
+test('googlecustomsearch plugin uriFor() missing "search" arguments', function (t) {
   // testCases map state descriptions to uriFor() arguments
   const testCases = {
     'all arguments are null': {

--- a/test/googlecustomsearchhsl.js
+++ b/test/googlecustomsearchhsl.js
@@ -1,0 +1,61 @@
+'use strict';
+const test = require('tape');
+const cheerio = require('cheerio');
+const plugin = require('../').googlecustomsearchhsl();
+const tester = require('@nihiliad/janus/uri-factory/plugin-tester')({runIntegrationTests: false});
+
+test('hsl googlecustomsearch plugin default scopes', function (t) {
+  t.deepEqual(plugin.scopes(), {}, 'scopes() correctly returns the default empty object');
+  t.end();
+});
+
+test('hsl googlecustomsearch plugin fields override', function (t) {
+  t.deepEqual(plugin.fields(), {}, 'fields correctly overridden with an empty object');
+  t.end();
+});
+
+test('hsl googlecustomsearch plugin baseUri()', function (t) {
+  tester.baseUri(t, plugin, 'https://hsl.lib.umn.edu/search');
+});
+
+test('hsl googlecustomsearch plugin emptySearchUri()', function (t) {
+  tester.emptySearchUri(t, plugin, 'https://hsl.lib.umn.edu/search');
+});
+
+test('hsl googlecustomsearch plugin uriFor() missing "search" arguments', function (t) {
+  // testCases map state descriptions to uriFor() arguments
+  const testCases = {
+    'all arguments are null': {
+      search: null,
+      scope: null,
+      field: null,
+    },
+  };
+  tester.missingSearchArgs(t, plugin, testCases);
+});
+
+test('hsl googlecustomsearch plugin uriFor() valid "search" arguments', function (t) {
+  // testCases map expected uri to uriFor() arguments
+  const testCases = {
+    'https://hsl.lib.umn.edu/search?query=anatomy': {
+      search: 'anatomy',
+      scope: null,
+      field: null,
+    },
+  };
+
+  function getResultCount (html) {
+    // const elem = $('#resInfo-1');
+    // // Displays like "About 1,294 results", strip out the comma
+    // const matches = $(elem[0]).text().trim().replace(/,/, '').match(/About (\d+) sorted/);
+    // const count = matches[1];
+    // return parseInt(count, 10);
+
+    // Our /search endpoint loads Google code that does search via XHR
+    // and returns to build results via JS. Current test runner
+    // does not support checking this, would need something like Selenium
+    return 1;
+  };
+
+  tester.validSearchArgs(t, plugin, testCases, getResultCount);
+});


### PR DESCRIPTION
Dumbest possible method of getting a new plugin to support https://hsl.lib.umn.edu/search (in dev at https://hsl-d8.dev.umn.edu/search)

This differs from the existing `GoogleCustomSearch` plugin _only_ in that the base URL is hsl.lib.umn.edu rather than www.lib.umn.edu, but does not make sense to create an HSL scope on that plugin because the main www search is not a superset of both. Right now they are implemented as two independent searches in Google Search Console.

### Alternative:
If we did keep the two within one plugin, an implementation might do something like `baseUri()` switching based on a scope:

```
// More or less something like this
baseUri() {
  return URI({
    protocol: 'https',
    hostname: scopeToHost(),
  }). //etc

function scopeToHost(scope) {
  return ({
    www: 'www.lib.umn.edu',
    hsl: 'hsl.lib.umn.edu',
  })[scope]
}
```