### PR TITLE
Support www, hsl scopes for googlecustomsearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Base site URLs are available as scopes
 
 scope                       | Name/Description | URL
 ----------------------------|--------------------------------|-----------------
-`www` (defaultif unspeficied) | https://www.lib.umn.edu/search | UL www website
+`www` (default if unspeficied) | https://www.lib.umn.edu/search | UL www website
 `hsl`                         | https://hsl.lib.umn.edu/search | HSL website
 
 Google Custom Search has no fields.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Plugins for the [Janus URI factory](https://github.com/UMNLibraries/janus#uri-fa
 
 - [Scopes and Formats](#scopes-and-formats)
 	- [ArchiveSpace](#archivespace)
-	- [GoogleCustomSearch](#googlecustomsearch)
+	- [GoogleCustomSearch](#google-custom-search)
 	- [MncatDiscovery](#mncatdiscovery)
 	- [Primo](#primo)
 	- [PubMed](#pubmed)
@@ -72,9 +72,16 @@ Articles and Scholarly Works          | https://conservancy.umn.edu/handle/11299
 
 ### Google Custom Search
 Performs a search via the Google Custom Search endpoint configured at
-https://www.lib.umn.edu/search.
+https://www.lib.umn.edu/search or https://hsl.lib.umn.edu/search
 
-Google Custom Search has no custom scopes and no fields.
+Base site URLs are available as scopes
+
+scope                       | Name/Description | URL
+----------------------------|--------------------------------|-----------------
+`www` (defaultif unspeficied) | https://www.lib.umn.edu/search | UL www website
+`hsl`                         | https://hsl.lib.umn.edu/search | HSL website
+
+Google Custom Search has no fields.
 
 ### MncatDiscovery
 Alias of [Primo](#primo).

--- a/lib/googlecustomsearch.js
+++ b/lib/googlecustomsearch.js
@@ -3,13 +3,26 @@ const stampit = require('stampit');
 const URI = require('urijs');
 const plugin = require('@nihiliad/janus/uri-factory/plugin');
 
-const googlecustomsearch = stampit()
+const googlecustomsearch = stampit({
+  props: {
+    defaultScope: 'www',
+    scope: null,
+  }
+})
 .methods({
   fields () { return {}; },
+  scopes() {
+    return {
+      www: 'www.lib.umn.edu',
+      hsl: 'hsl.lib.umn.edu',
+    };
+  },
   baseUri () {
     return URI({
       protocol: 'https',
-      hostname: 'www.lib.umn.edu',
+      hostname: (() => {
+        return this.scopes()[this.scope || this.defaultScope]
+      })(),
     }).segmentCoded([
       'search',
     ]).query({
@@ -17,11 +30,18 @@ const googlecustomsearch = stampit()
     });
   },
   uriFor (search, scope, field) {
+    const warnings = [];
+
     if (!search) {
       return [
         this.emptySearchWarning,
         this.emptySearchUri(),
       ];
+    }
+    this.scope = scope || this.defaultScope;
+    if (!(scope in this.scopes())) {
+      warnings.push('Unrecognized scope: "' + scope + '", using www');
+      this.scope = this.defaultScope;
     }
     return [
       '',

--- a/test/googlecustomsearch.js
+++ b/test/googlecustomsearch.js
@@ -4,25 +4,25 @@ const cheerio = require('cheerio');
 const plugin = require('../').googlecustomsearch();
 const tester = require('@nihiliad/janus/uri-factory/plugin-tester')({runIntegrationTests: false});
 
-test('pubmed plugin default scopes', function (t) {
-  t.deepEqual(plugin.scopes(), {}, 'scopes() correctly returns the default empty object');
+test('googlecustomsearch plugin scopes', function (t) {
+  t.deepEqual(plugin.scopes()['hsl'], 'hsl.lib.umn.edu', 'scopes() correctly returns and indexable object');
   t.end();
 });
 
-test('pubmed plugin fields override', function (t) {
+test('googlecustomsearch plugin fields override', function (t) {
   t.deepEqual(plugin.fields(), {}, 'fields correctly overridden with an empty object');
   t.end();
 });
 
-test('pubmed plugin baseUri()', function (t) {
+test('googlecustomsearch plugin baseUri() defaults', function (t) {
   tester.baseUri(t, plugin, 'https://www.lib.umn.edu/search');
 });
 
-test('pubmed plugin emptySearchUri()', function (t) {
+test('googlecustomsearch plugin emptySearchUri()', function (t) {
   tester.emptySearchUri(t, plugin, 'https://www.lib.umn.edu/search');
 });
 
-test('pubmed plugin uriFor() missing "search" arguments', function (t) {
+test('googlecustomsearch plugin uriFor() missing "search" arguments', function (t) {
   // testCases map state descriptions to uriFor() arguments
   const testCases = {
     'all arguments are null': {
@@ -40,6 +40,16 @@ test('googlecustomsearch plugin uriFor() valid "search" arguments', function (t)
     'https://www.lib.umn.edu/search?query=math': {
       search: 'math',
       scope: null,
+      field: null,
+    },
+    'https://www.lib.umn.edu/search?query=wwwmath': {
+      search: 'wwwmath',
+      scope: 'www',
+      field: null,
+    },
+    'https://hsl.lib.umn.edu/search?query=math': {
+      search: 'math',
+      scope: 'hsl',
       field: null,
     },
   };


### PR DESCRIPTION
Related to #26 but an alternative/better implementation!

Instead of an entirely new Google Custom Search plugin for HSL only, adds scopes to the existing googlecustomsearch plugin, defaulting to `www` if unspecified.

Because `baseUri()` can't accept arguments from the base implementation, it isn't possible to pass it a scope to switch hostnames on - instead the current scope goes into a property that gets redefined on calls to `uriFor()` and built with a lambda in `baseUri()`.