### PR TITLE
Use a tab param with Primo default scope

### DIFF
--- a/lib/primo.js
+++ b/lib/primo.js
@@ -6,6 +6,8 @@ const plugin = require('@nihiliad/janus/uri-factory/plugin')
 // Much of this is based on the document 'Linking to Primo':
 // https://docs.google.com/a/umn.edu/document/d/1MufWU9IEJVGM1zrOPaIWhP0nrgvMcYteJCU57fHp_7k/edit?usp=sharing
 
+const DEFAULT_SCOPE = 'TwinCitiesCampus_and_CI'
+
 const primo = stampit()
   .methods({
   // TODO: Not sure that this simple mapping makes sense for this class, for Primo URLs.
@@ -121,7 +123,13 @@ const primo = stampit()
           warnings.push('Unrecognized scope: "' + scope + '"')
         }
       }
-      queryParams.search_scope = primoScope || 'TwinCitiesCampus_and_CI'
+      queryParams.search_scope = primoScope || DEFAULT_SCOPE
+
+      if (queryParams.search_scope === DEFAULT_SCOPE) {
+        // This tab parameter needs to be included with the default scope in
+        // order to prevent Primo from displaying the Rapido 'expand' option.
+        queryParams.tab = 'Everything'
+      }
 
       let primoField
       if (field) {

--- a/test/primo.js
+++ b/test/primo.js
@@ -49,22 +49,22 @@ test('primo uriFor() missing "search" arguments', function (t) {
 })
 
 test('primo invalid field args', function (t) {
-  tester.invalidFieldArgs(t, plugin, 'https://primo.lib.umn.edu/discovery/search?vid=01UMN_INST%3ATWINCITIES&lang=en&search_scope=TwinCitiesCampus_and_CI&query=any%2Ccontains%2Cdarwin')
+  tester.invalidFieldArgs(t, plugin, 'https://primo.lib.umn.edu/discovery/search?vid=01UMN_INST%3ATWINCITIES&lang=en&search_scope=TwinCitiesCampus_and_CI&tab=Everything&query=any%2Ccontains%2Cdarwin')
 })
 
 test('primo invalid scope args', function (t) {
-  tester.invalidScopeArgs(t, plugin, 'https://primo.lib.umn.edu/discovery/search?vid=01UMN_INST%3ATWINCITIES&lang=en&search_scope=TwinCitiesCampus_and_CI&query=any%2Ccontains%2Cdarwin')
+  tester.invalidScopeArgs(t, plugin, 'https://primo.lib.umn.edu/discovery/search?vid=01UMN_INST%3ATWINCITIES&lang=en&search_scope=TwinCitiesCampus_and_CI&tab=Everything&query=any%2Ccontains%2Cdarwin')
 })
 
 test('primo uriFor() valid "search" arguments', function (t) {
   // testCases map expectedUrl to uriFor arguments
   const testCases = {
-    'https://primo.lib.umn.edu/discovery/search?vid=01UMN_INST%3ATWINCITIES&lang=en&search_scope=TwinCitiesCampus_and_CI&query=any%2Ccontains%2Cdarwin': {
+    'https://primo.lib.umn.edu/discovery/search?vid=01UMN_INST%3ATWINCITIES&lang=en&search_scope=TwinCitiesCampus_and_CI&tab=Everything&query=any%2Ccontains%2Cdarwin': {
       search: 'darwin',
       scope: null,
       field: null
     },
-    'https://primo.lib.umn.edu/discovery/search?vid=01UMN_INST%3ATWINCITIES&lang=en&search_scope=TwinCitiesCampus_and_CI&query=sub%2Ccontains%2Cdarwin': {
+    'https://primo.lib.umn.edu/discovery/search?vid=01UMN_INST%3ATWINCITIES&lang=en&search_scope=TwinCitiesCampus_and_CI&tab=Everything&query=sub%2Ccontains%2Cdarwin': {
       search: 'darwin',
       scope: null,
       field: 'subject'
@@ -85,49 +85,49 @@ test('primo uriFor() valid "search" arguments', function (t) {
       field: 'title',
       format: 'books'
     },
-    'https://primo.lib.umn.edu/discovery/search?vid=01UMN_INST%3ATWINCITIES&lang=en&search_scope=TwinCitiesCampus_and_CI&query=any%2Ccontains%2Cdarwin&mfacet=rtype%2Cinclude%2Carchive%2C1&mfacet=rtype%2Cinclude%2Carchival_material_manuscripts%2C1': {
+    'https://primo.lib.umn.edu/discovery/search?vid=01UMN_INST%3ATWINCITIES&lang=en&search_scope=TwinCitiesCampus_and_CI&tab=Everything&query=any%2Ccontains%2Cdarwin&mfacet=rtype%2Cinclude%2Carchive%2C1&mfacet=rtype%2Cinclude%2Carchival_material_manuscripts%2C1': {
       search: 'darwin',
       scope: null,
       field: null,
       format: 'archive'
     },
-    'https://primo.lib.umn.edu/discovery/search?vid=01UMN_INST%3ATWINCITIES&lang=en&search_scope=TwinCitiesCampus_and_CI&query=any%2Ccontains%2Cdarwin&facet=rtype%2Cinclude%2Caudios': {
+    'https://primo.lib.umn.edu/discovery/search?vid=01UMN_INST%3ATWINCITIES&lang=en&search_scope=TwinCitiesCampus_and_CI&tab=Everything&query=any%2Ccontains%2Cdarwin&facet=rtype%2Cinclude%2Caudios': {
       search: 'darwin',
       scope: null,
       field: null,
       format: 'audios'
     },
-    'https://primo.lib.umn.edu/discovery/search?vid=01UMN_INST%3ATWINCITIES&lang=en&search_scope=TwinCitiesCampus_and_CI&query=any%2Ccontains%2Cdarwin&facet=rtype%2Cinclude%2Cjournals': {
+    'https://primo.lib.umn.edu/discovery/search?vid=01UMN_INST%3ATWINCITIES&lang=en&search_scope=TwinCitiesCampus_and_CI&tab=Everything&query=any%2Ccontains%2Cdarwin&facet=rtype%2Cinclude%2Cjournals': {
       search: 'darwin',
       scope: null,
       field: null,
       format: 'journals'
     },
-    'https://primo.lib.umn.edu/discovery/search?vid=01UMN_INST%3ATWINCITIES&lang=en&search_scope=TwinCitiesCampus_and_CI&query=any%2Ccontains%2Cdarwin&facet=rtype%2Cinclude%2Cmaps': {
+    'https://primo.lib.umn.edu/discovery/search?vid=01UMN_INST%3ATWINCITIES&lang=en&search_scope=TwinCitiesCampus_and_CI&tab=Everything&query=any%2Ccontains%2Cdarwin&facet=rtype%2Cinclude%2Cmaps': {
       search: 'darwin',
       scope: null,
       field: null,
       format: 'maps'
     },
-    'https://primo.lib.umn.edu/discovery/search?vid=01UMN_INST%3ATWINCITIES&lang=en&search_scope=TwinCitiesCampus_and_CI&query=any%2Ccontains%2Cdarwin&facet=rtype%2Cinclude%2Cscores': {
+    'https://primo.lib.umn.edu/discovery/search?vid=01UMN_INST%3ATWINCITIES&lang=en&search_scope=TwinCitiesCampus_and_CI&tab=Everything&query=any%2Ccontains%2Cdarwin&facet=rtype%2Cinclude%2Cscores': {
       search: 'darwin',
       scope: null,
       field: null,
       format: 'scores'
     },
-    'https://primo.lib.umn.edu/discovery/search?vid=01UMN_INST%3ATWINCITIES&lang=en&search_scope=TwinCitiesCampus_and_CI&query=any%2Ccontains%2Cdarwin&facet=rtype%2Cinclude%2Cvideos': {
+    'https://primo.lib.umn.edu/discovery/search?vid=01UMN_INST%3ATWINCITIES&lang=en&search_scope=TwinCitiesCampus_and_CI&tab=Everything&query=any%2Ccontains%2Cdarwin&facet=rtype%2Cinclude%2Cvideos': {
       search: 'darwin',
       scope: null,
       field: null,
       format: 'videos'
     },
-    'https://primo.lib.umn.edu/discovery/search?vid=01UMN_INST%3ATWINCITIES&lang=en&search_scope=TwinCitiesCampus_and_CI&query=any%2Ccontains%2Cdarwin&facet=tlevel%2Cinclude%2Conline_resources%24%24ITWINCITIES': {
+    'https://primo.lib.umn.edu/discovery/search?vid=01UMN_INST%3ATWINCITIES&lang=en&search_scope=TwinCitiesCampus_and_CI&tab=Everything&query=any%2Ccontains%2Cdarwin&facet=tlevel%2Cinclude%2Conline_resources%24%24ITWINCITIES': {
       search: 'darwin',
       scope: null,
       field: null,
       format: 'online'
     },
-    'https://primo.lib.umn.edu/discovery/search?vid=01UMN_INST%3ATWINCITIES&lang=en&search_scope=TwinCitiesCampus_and_CI&query=any%2Ccontains%2Cdarwin&mfacet=rtype%2Cinclude%2Caudios%2C1&mfacet=rtype%2Cinclude%2Cimages%2C1&mfacet=rtype%2Cinclude%2Cvideos%2C1': {
+    'https://primo.lib.umn.edu/discovery/search?vid=01UMN_INST%3ATWINCITIES&lang=en&search_scope=TwinCitiesCampus_and_CI&tab=Everything&query=any%2Ccontains%2Cdarwin&mfacet=rtype%2Cinclude%2Caudios%2C1&mfacet=rtype%2Cinclude%2Cimages%2C1&mfacet=rtype%2Cinclude%2Cvideos%2C1': {
       search: 'darwin',
       scope: null,
       field: null,


### PR DESCRIPTION
When using the default Primo scope (TwinCitiesCampus_and_CI), add a `&tab=Everything` to the target URL. This ensures that Primo does not display the Rapido "expand your search" suggestion in the search results page, which is redundant when using the default `TwinCitesCampus_and_CI` scope.