### PR TITLE
Adds support for DSpace 7 to Conservancy plugin

### DIFF
--- a/lib/conservancy.js
+++ b/lib/conservancy.js
@@ -10,7 +10,7 @@ const conservancy = stampit()
         protocol: 'https',
         hostname: 'conservancy.umn.edu'
       }).segmentCoded([
-        'discover'
+        'search'
       ])
     },
 

--- a/lib/conservancy.js
+++ b/lib/conservancy.js
@@ -57,12 +57,15 @@ const conservancy = stampit()
       // '11299/169792': 'Articles and Scholarly Works'
       // '11299/166578': 'Data Repository for U of M (DRUM)'
       // '11299/165856': 'University Digital Conservancy Inbox for New Users'
+      // '4b8b835d-e1aa-4f79-bc86-f031b1d5882f': Beginning DSpace 7, UUID values 8-4-4-4-12 char strings
       let udcScope = ''
       if (scope) {
         if (scope === '/') {
           udcScope = scope
         } else if (/^\d+$/.exec(scope)) {
           udcScope = '11299/' + scope
+        } else if (/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/.exec(scope)) {
+          udcScope = scope
         } else {
         // warnings.push('Unrecognized scope "' + scope + '". Scope must be an integer greater than 0.');
           warnings.push('Unrecognized scope: "' + scope + '"')

--- a/test/conservancy.js
+++ b/test/conservancy.js
@@ -72,6 +72,11 @@ test('conservancy uriFor() valid "search" arguments', function (t) {
       search: 'minnesota',
       scope: '/', // All of the UDC
       field: 'title'
+    },
+    'https://conservancy.umn.edu/search?query=minnesota&scope=4b8b835d-e1aa-4f79-bc86-f031b1d5882f': {
+      search: 'minnesota',
+      scope: '4b8b835d-e1aa-4f79-bc86-f031b1d5882f', // UUID for DRUM
+      field: null
     }
   }
 

--- a/test/conservancy.js
+++ b/test/conservancy.js
@@ -8,7 +8,7 @@ test('setup', async function (t) {
 })
 
 test('conservancy baseUri()', function (t) {
-  tester.baseUri(t, plugin, 'https://conservancy.umn.edu/discover')
+  tester.baseUri(t, plugin, 'https://conservancy.umn.edu/search')
 })
 
 test('conservancy emptySearchUri()', function (t) {
@@ -43,32 +43,32 @@ test('conservancy uriFor() missing "search" arguments', function (t) {
 })
 
 test('conservancy invalid field args', function (t) {
-  tester.invalidFieldArgs(t, plugin, 'https://conservancy.umn.edu/discover?query=darwin')
+  tester.invalidFieldArgs(t, plugin, 'https://conservancy.umn.edu/search?query=darwin')
 })
 
 test('conservancy invalid scope args', function (t) {
-  tester.invalidScopeArgs(t, plugin, 'https://conservancy.umn.edu/discover?query=darwin')
+  tester.invalidScopeArgs(t, plugin, 'https://conservancy.umn.edu/search?query=darwin')
 })
 
 test('conservancy uriFor() valid "search" arguments', function (t) {
   // testCases map expectedUrl to uriFor arguments
   const testCases = {
-    'https://conservancy.umn.edu/discover?query=darwin': {
+    'https://conservancy.umn.edu/search?query=darwin': {
       search: 'darwin',
       scope: null,
       field: null
     },
-    'https://conservancy.umn.edu/discover?query=darwin&filtertype_1=subject&filter_relational_operator_1=contains&filter_1=darwin': {
+    'https://conservancy.umn.edu/search?query=darwin&filtertype_1=subject&filter_relational_operator_1=contains&filter_1=darwin': {
       search: 'darwin',
       scope: null,
       field: 'subject'
     },
-    'https://conservancy.umn.edu/discover?query=sociology&scope=11299%2F1': {
+    'https://conservancy.umn.edu/search?query=sociology&scope=11299%2F1': {
       search: 'sociology',
       scope: '1', // University of Minnesota - Twin Cities
       field: null
     },
-    'https://conservancy.umn.edu/discover?query=minnesota&scope=%2F&filtertype_1=title&filter_relational_operator_1=contains&filter_1=minnesota': {
+    'https://conservancy.umn.edu/search?query=minnesota&scope=%2F&filtertype_1=title&filter_relational_operator_1=contains&filter_1=minnesota': {
       search: 'minnesota',
       scope: '/', // All of the UDC
       field: 'title'


### PR DESCRIPTION
* Search path `/discover` changes to `/search` for DSpace 7
* UUIDs are now valid scope as hex strings of 8-4-4-4-12 characters

More work will be needed to add full support for the filter parameter. For now, we need this as a minimum to get it working for existing search forms.