### PR TITLE
Conservancy field parameter fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,21 +55,20 @@ YMCA (Krautz Family YMCA Archives) | 7
 
 ### Conservancy
 
-UDC scopes can be either a single slash (/), for all or the UDC, or
-id/collectionId, where id and collectionId are both integers. id always seems
-to be 1129, and Conservancy scope handling depends on that being true.
-We require users to pass in only the collectionId. A list can be found at:
+UDC scopes in DSpace 7.x take the form of a UUID, where a UUID may represent
+either a community (such as a system campus) or a more limited collection. A
+scope query can therefore limit results at either of those levels.
+
+Available community and collection scopes can be found at:
 
 https://conservancy.umn.edu/community-list
 
-The URLs listed there are all of the form: https://conservancy.umn.edu/handle/11299/collectionId
-
 Examples:
 
-Name/Description                      | Collection URL                                  | Value
---------------------------------------|-------------------------------------------------|-------------
-University of Minnesota - Twin Cities | https://conservancy.umn.edu/handle/11299/1      | 1
-Articles and Scholarly Works          | https://conservancy.umn.edu/handle/11299/169792 | 169792
+Name/Description                      | Community or Collection URL                     | Scope Value
+--------------------------------------|-------------------------------------------------|---------------------------------
+University of Minnesota - Twin Cities | https://conservancy.umn.edu/communities/600d3b06-e18e-4f60-aef0-ae4ad51c5c2b | 600d3b06-e18e-4f60-aef0-ae4ad51c5c2b
+Articles and Scholarly Works          | https://conservancy.umn.edu/collections/06a2bbc2-0c84-4c15-913a-4e6aef330315 | 06a2bbc2-0c84-4c15-913a-4e6aef330315
 
 ### Google Custom Search
 Performs a search via the Google Custom Search endpoint configured at

--- a/lib/conservancy.js
+++ b/lib/conservancy.js
@@ -80,12 +80,9 @@ const conservancy = stampit()
         const fields = this.fields()
         if (field in fields) {
           udcField = fields[field]
-          // Not sure what the '_1' means at the end of all these 'filter*' param
-          // names. Sometimes the UDC sets it to other integers, like 0, but 1
-          // always seems to work for our purposes.
-          queryParams.filtertype_1 = udcField
-          queryParams.filter_relational_operator_1 = 'contains'
-          queryParams.filter_1 = search
+          // Filter query in DSpace 7.x takes the form &f.fieldname=searchstring,operator
+          // e.g. &f.title=darwin,contains
+          queryParams['f.' + udcField] = search + ',contains'
         } else {
           warnings.push('Unrecognized field: "' + field + '"')
         }

--- a/test/conservancy.js
+++ b/test/conservancy.js
@@ -58,7 +58,7 @@ test('conservancy uriFor() valid "search" arguments', function (t) {
       scope: null,
       field: null
     },
-    'https://conservancy.umn.edu/search?query=darwin&filtertype_1=subject&filter_relational_operator_1=contains&filter_1=darwin': {
+    'https://conservancy.umn.edu/search?query=darwin&f.subject=darwin%2Ccontains': {
       search: 'darwin',
       scope: null,
       field: 'subject'


### PR DESCRIPTION
Changes the old DSpace filtering via field param to use the DSpace 7 method which looks like 

```
&f.subject=a+subject,contains
&f.title=the+title,equals
```

We continue only to support `contains` as the operator.

This also completes the documentation for UUID-based DSpace 7 scopes.