### PR TITLE
Update primo online resources parameter

### DIFF
--- a/lib/primo.js
+++ b/lib/primo.js
@@ -158,7 +158,7 @@ const primo = stampit()
           } else if (format === 'media') {
             queryParams.mfacet = ['rtype,include,audios,1', 'rtype,include,images,1', 'rtype,include,videos,1']
           } else if (format === 'online') {
-            queryParams.facet = ['tlevel,include,online_resources$$ITWINCITIES']
+            queryParams.facet = ['tlevel,include,online_resources']
           } else {
             queryParams.facet = 'rtype,include,' + format
           }

--- a/test/primo.js
+++ b/test/primo.js
@@ -121,7 +121,7 @@ test('primo uriFor() valid "search" arguments', function (t) {
       field: null,
       format: 'videos'
     },
-    'https://primo.lib.umn.edu/discovery/search?vid=01UMN_INST%3ATWINCITIES&lang=en&search_scope=TwinCitiesCampus_and_CI&tab=Everything&query=any%2Ccontains%2Cdarwin&facet=tlevel%2Cinclude%2Conline_resources%24%24ITWINCITIES': {
+    'https://primo.lib.umn.edu/discovery/search?vid=01UMN_INST%3ATWINCITIES&lang=en&search_scope=TwinCitiesCampus_and_CI&tab=Everything&query=any%2Ccontains%2Cdarwin&facet=tlevel%2Cinclude%2Conline_resources': {
       search: 'darwin',
       scope: null,
       field: null,


### PR DESCRIPTION
Remove `$$ITWINCITIES` from the online resources facet parameter. This is a legacy BO value that is harmless in VE at the moment, but it will probably cause issues in the next gen UI (NDE).